### PR TITLE
Override active hint

### DIFF
--- a/src/cmds/hook/active.sh
+++ b/src/cmds/hook/active.sh
@@ -1,5 +1,7 @@
 # shellcheck shell=bash
+MESSAGE=${FIRSTAIDE_ACTIVE_MESSAGE:-"aide build help"}
+UNDERLINE=${MESSAGE//?/^}
 log_status "$(okay OKAY): $(em 'Nix environment is up-to-date!')" >&2
 log_status "This is a $(em minimal environment); subprojects may not be built." >&2
-log_status "--> Use $(em aide build help) to find out what to do next." >&2
-log_status "        $(em ^^^^^^^^^^^^^^^)" >&2
+log_status "--> Use $(em $MESSAGE) to find out what to do next." >&2
+log_status "        $(em $UNDERLINE)" >&2

--- a/src/cmds/hook/active.sh
+++ b/src/cmds/hook/active.sh
@@ -1,7 +1,5 @@
 # shellcheck shell=bash
-MESSAGE=${FIRSTAIDE_ACTIVE_MESSAGE:-"aide build help"}
-UNDERLINE=${MESSAGE//?/^}
 log_status "$(okay OKAY): $(em 'Nix environment is up-to-date!')" >&2
 log_status "This is a $(em minimal environment); subprojects may not be built." >&2
-log_status "--> Use $(em $MESSAGE) to find out what to do next." >&2
-log_status "        $(em $UNDERLINE)" >&2
+log_status "--> Use $(em __MESSAGE__) to find out what to do next." >&2
+log_status "        $(m=__MESSAGE__ && em "${m//?/^}")" >&2

--- a/src/cmds/hook/inactive.sh
+++ b/src/cmds/hook/inactive.sh
@@ -1,4 +1,3 @@
 # shellcheck shell=bash
 log_status "$(error ERROR): $(em 'Nix environment is not yet built!')" >&2
 log_status "--> Use $(em firstaide build) to build it." >&2
-

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,7 @@ pub struct Config {
     build_exe: PathBuf,
     watch_exe: PathBuf,
     self_exe: PathBuf,
+    pub messages: ConfigMessages,
 }
 
 #[derive(Debug, Deserialize)]
@@ -57,6 +58,21 @@ struct ConfigData {
     cache_dir: PathBuf,
     build_exe: PathBuf,
     watch_exe: PathBuf,
+    #[serde(default)]
+    messages: ConfigMessages,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ConfigMessages {
+    pub getting_started: String,
+}
+
+impl Default for ConfigMessages {
+    fn default() -> Self {
+        Self {
+            getting_started: "aide --help".into(),
+        }
+    }
 }
 
 impl Config {
@@ -87,6 +103,7 @@ impl Config {
             build_exe: datum_dir.join(config_data.build_exe).absolutize()?,
             watch_exe: datum_dir.join(config_data.watch_exe).absolutize()?,
             self_exe: env::current_exe()?,
+            messages: config_data.messages,
         })
     }
 


### PR DESCRIPTION
With this you can add a section to `.firstaide.toml` like so:

```toml
[messages]
getting_started = "Woohaa!"
```

and that message will appear instead of `aide build help`.

This PR also changes the default message to `aide --help`.
