### PR TITLE
Load cache fallback

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -17,6 +17,13 @@ impl Cache {
         bincode::deserialize(&data)
     }
 
+    pub fn load_with_fallback<T: AsRef<Path>>(filename: T, fallback: T) -> bincode::Result<Self> {
+        Self::load(filename).or_else(|_err| {
+            log::debug!("Loading fallback, {}", fallback.as_ref().display());
+            Self::load(fallback)
+        })
+    }
+
     pub fn save<T: AsRef<Path>>(&self, filename: T) -> bincode::Result<()> {
         Ok(fs::write(filename, bincode::serialize(self)?)?)
     }

--- a/src/cmds/hook.rs
+++ b/src/cmds/hook.rs
@@ -117,8 +117,9 @@ pub fn run(args: &clap::ArgMatches) -> Result {
 
     let sums_now = sums::Checksums::from(&config.watch_files()?)?;
     let cache_file = config.cache_file(&sums_now);
+    let cache_file_fallback = config.cache_file_most_recent();
 
-    match cache::Cache::load(&cache_file) {
+    match cache::Cache::load_with_fallback(&cache_file, &cache_file_fallback) {
         Ok(cache) => {
             // Filter out DIRENV_ and SSH_ vars from cached diff, then use it to
             // extend the parent's environment diff.

--- a/src/cmds/status.rs
+++ b/src/cmds/status.rs
@@ -59,8 +59,9 @@ pub fn run(args: &clap::ArgMatches) -> Result {
 
     let sums_now = sums::Checksums::from(&config.watch_files()?)?;
     let cache_file = config.cache_file(&sums_now);
+    let cache_file_fallback = config.cache_file_most_recent();
 
-    let status = match cache::Cache::load(&cache_file) {
+    let status = match cache::Cache::load_with_fallback(&cache_file, &cache_file_fallback) {
         Ok(cache) => {
             if sums::equal(&sums_now, &cache.sums) {
                 EnvironmentStatus::Okay

--- a/src/config.rs
+++ b/src/config.rs
@@ -210,6 +210,10 @@ impl Config {
         self.cache_dir.join(format!("cache.{}", sums.sig()))
     }
 
+    pub fn cache_file_most_recent(&self) -> PathBuf {
+        self.cache_dir.join("cache")
+    }
+
     pub fn build_log_file(&self) -> PathBuf {
         self.cache_dir.join("build.log")
     }


### PR DESCRIPTION
For each build, update a `cache` symlink to point to it.

This acts as a fallback cache when a cache corresponding to the current file sums does not exist. The fallback is to the most recently built cache, not necessarily to some "closest" match because it's not clear how exactly we might calculate closeness. Recentness is a reasonably proxy for now.
