### PR TITLE
Use a human- and machine-readable date in build.log.

### DIFF
--- a/src/cmds/build.rs
+++ b/src/cmds/build.rs
@@ -8,7 +8,6 @@ use std::fmt;
 use std::fs;
 use std::io::{self, Write};
 use std::os::unix;
-use std::time::UNIX_EPOCH;
 use tempfile;
 
 pub const NAME: &str = "build";
@@ -174,11 +173,11 @@ fn build(config: config::Config) -> Result {
             .append(true)
             .create(true)
             .open(&config.build_log_file())?;
-        let build_time = UNIX_EPOCH.elapsed().map_or(0, |d| d.as_secs());
+        let build_time = chrono::offset::Local::now();
         writeln!(
             &mut build_log,
-            "{:010} {}",
-            &build_time,
+            "{}  {}",
+            &build_time.format("%+"),
             &cache_file.display()
         )?;
         build_log.sync_all()?;


### PR DESCRIPTION
Previously is was printing seconds since the UNIX epoch, which doesn't mean much to a human. Now it prints something like: 2020-03-28T16:05:12.635571+01:00.